### PR TITLE
Changed pylint workflow to work on version 3.13 only

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
# Pull Request
## Description
Changed pylint workflow to run only on python 3.13
## Issues this fixes
Closes: #92 
## Changes
Changed yml file 
## Checklist
[ ] - Pylinted
[ ] - Tested
[ ] - Documented
